### PR TITLE
compute flow travel distance between cells to determine the slope.

### DIFF
--- a/slopeAlongFlow.m
+++ b/slopeAlongFlow.m
@@ -22,9 +22,12 @@
                     % if this cell is a channel cell, look up the cell(s) it
                     % flows to
                     flowsTo = grid.flowsTo{k};
+                    [ri,ci] = ind2sub(grid.size, k); % row,col of cell i
                     S_temp = nan(size(flowsTo));
                     for l=1:numel(flowsTo)
-                        S_temp(l) = -(grid.z(flowsTo(l)) - grid.z(k)); % downhill slopes are defined as positive
+                        [rj,cj] = ind2sub(grid.size, flowsTo(l)); % row,col of cell j
+                        distance = sqrt((rj-ri)^2 + (cj-ci)^2) * grid.dx;  % distance along flow
+                        S_temp(l) = -(grid.z(flowsTo(l)) - grid.z(k)) / distance; % downhill slopes are defined as positive
                     end
                     grid.S.alongFlow(k) = max(S_temp); % if there are multiple flowsTo cells, treat slope as the maximum of slopes to each cell
                 end         


### PR DESCRIPTION
When reviewing implementation I came across what I believe is a bug. In `slopeAlongFlow`, the "slope" is computed as just the cell elevation difference, i.e., there is no distance denominator.

This led to slopes approximately two orders of magnitude too high (`dx` default was 100), which made flow depths very small, and was making it really difficult for the channel avulsion criteria to be met upstream. I have implemented a distance compute between cells `i` and `j` to add a distance denominator.

Do you agree this is a bug and that the distance should be included here as a denominator?

Todo:
- [x] a 10-year run to compare with the previous implementation

Below is the result from a 10-year run with the slope denominator implemented. the deposit seems more symmetrical, which might indicate avulsions nearer to the inlet. Still, something is off with the bed elevations though (e.g., 1800 m??)
![image](https://user-images.githubusercontent.com/8801322/127871141-0e7fa741-fa3a-4ae3-971a-8a27ac83d695.png)
