### PR TITLE
Prevent corners during avulsions

### DIFF
--- a/source/propagateAvulsion.m
+++ b/source/propagateAvulsion.m
@@ -119,8 +119,8 @@ function [forbiddenCells] = checkNeighborsChannelsCrossover(grid, indCurrent, ng
     % option flag
     cornerOption = 'connected'; % 'connected' | 'present'
 
-    % preallocate the forbidden corners, same shape as forbiddenCells
-    forbiddenCorners = false(1,8);
+    % preallocate the forbidden corners, shape is for four possible corners
+    forbiddenCorners = false(1,4);
 
     % loop through
     for i=1:4
@@ -135,19 +135,22 @@ function [forbiddenCells] = checkNeighborsChannelsCrossover(grid, indCurrent, ng
                     % the channel cells are connected
 
                     % add this corner cell to the list of forbiddenCorners
-                    forbiddenCorners(corners(i)) = true;
+                    forbiddenCorners(i) = true;
                 end
 
             elseif strcmp(cornerOption, 'present')
                 % doesn't matter if these are connected
 
                 % add this corner to the list of forbiddenCorners
-                forbiddenCorners(corners(i)) = true;
+                forbiddenCorners(i) = true;
 
             end
         end
     end
+    
+    % convert the corners boolen to cell indices
+    forbiddenCorners = nghbrs(corners(forbiddenCorners));
 
     % anything that was forbidden or is a forbidden corner.
-    forbiddenCells = or(forbiddenCorners, forbiddenCells);
+    forbiddenCells = unique([forbiddenCorners, forbiddenCells]);
 end


### PR DESCRIPTION
This PR implements a routine to prevent corners from being chosen during avulsion propagation, when it would form a crossover channel (e.g., #24).

**Any avulsion pathfinding that would result in a crossover channel being formed is now prevented.**

I implemented an optionFlag to control the special case we discussed, where two corners are occupied, but by different channels. The implemented behavior is to prevent this corner cell only when the two constraining cells are actually connected, rather than just occupied. That is, the corner cell is allowed in the avulsion pathfinding if the constraining cells are not connected.

I left the other implementation in place, and it could be tested with the flag set to `'present'`, Leaving this in adds some computational overhead, but I think it's pretty inexpensive given the pathfinding is infrequent and two constraining cells being occupied is even more infrequent. But, we could just remove the other implementation too.

For an example, the implementation seems to correctly resolve complex pathways, and I have not yet encountered any cases where a crossover has been created.

![image](https://user-images.githubusercontent.com/8801322/129916728-7bebfb05-fdc8-4fda-b0dc-59ba5979f441.png)


closes #24 