### PR TITLE
Basic checkpoint loading / restart file operations

### DIFF
--- a/sunFanModel.m
+++ b/sunFanModel.m
@@ -18,12 +18,10 @@ addpath(genpath('source'))
 % from a previous model run. To start a new run, use `false`.
 loadCheckpoint = false;
 
-rng(12)
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Set model parameters 
 runName = 'run1'; % base name for run and file output
-clobber = true; % whether to overwrite output folder if exists
+clobber = false; % whether to overwrite output folder if exists
 
 % Dimensionless parameters (from Table 1)
 alpha_so = 11.25;


### PR DESCRIPTION
This PR implements a rudimentary checkpointing, to be able to resume from a file and continue the run. This is really helpful for debugging a run.

Works by specifying a string for the `loadCheckpoint` flag at the top of the file.