### PR TITLE
basic channel cell labels

### DIFF
--- a/source/plot/gridLabelChannelInds.m
+++ b/source/plot/gridLabelChannelInds.m
@@ -1,5 +1,8 @@
 function gridLabelChannelInds(grid)
-
+%gridLabelChannelInds Add cell index labels to a plot
+% Adds the cell indices of cells marked by `grid.channelFlag` to the
+% current axis.
+    
     for k=1:numel(grid.x)
         if grid.channelFlag(k)
             [x,y] = ind2sub(grid.size, k);


### PR DESCRIPTION
There's probably a smarter way to do this, but it has been **extremely** helpful for my debugging. 

![image](https://user-images.githubusercontent.com/8801322/130153010-ff53dbdb-bc45-42e0-a5b2-8e7e987a3f07.png)


here's an incredibly helpful one-liner that is always right in my console history :laughing: 
```
figure(); imagesc(grid.z); colormap('summer'); hold on; gridToChannelArrows(grid); gridLabelChannelInds(grid);
```