### PR TITLE
Variable ocean level

### DIFF
--- a/source/checkParameters.m
+++ b/source/checkParameters.m
@@ -24,7 +24,10 @@ if ~isnumeric(parameters.Qs_inlet),error(msg); end
 if ~isnumeric(parameters.Qw_threshold),error(msg); end
 if ~isnumeric(parameters.Qw_mismatch_tolerance),error(msg); end
 if ~isnumeric(parameters.D),error(msg); end
-if ~isnumeric(parameters.oceanLevel),error(msg); end
+if ~isstruct(parameters.oceanLevel),error(msg); end
+if ne(numel(parameters.oceanLevel.timeStart_yr),numel(parameters.oceanLevel.z))
+    error('In oceanLevel, fields timeStart_yr and z must have the same number of elements');
+end
 if ~isstruct(parameters.grid), error(msg); end
 if ~isnumeric(parameters.t), error(msg); end
 if ~isnumeric(parameters.tStep_sec), error(msg); end

--- a/source/makeGrids.m
+++ b/source/makeGrids.m
@@ -50,7 +50,7 @@ function grid =  makeGrids(grid,oceanLevel) % nested function
         grid.flowsFrom = cell(grid.size);
         
         % create grids to flag other attributes
-        grid.oceanFlag = grid.z<=oceanLevel; % flag to identify whether a cell is in the ocean. Eventually this can be a check at each time step. 
+        grid.oceanFlag = grid.z<=oceanLevel.z(1); % flag to identify whether a cell is in the ocean, using initial ocean level.
         grid.channelFlag = false(grid.size); % flag to identify whether a cell is part of a channel
     end
     

--- a/source/sunFanModel.m
+++ b/source/sunFanModel.m
@@ -128,7 +128,8 @@ iter = 0;
         grid = updateSlope(grid,boundaryCondition,t); 
 
         % update grid.oceanFlag following topography update
-        grid.oceanFlag = grid.z <= oceanLevel;
+        indOceanLevel = find(t>=oceanLevel.timeStart_yr,1,'last');
+        grid.oceanFlag = grid.z <= oceanLevel.z(indOceanLevel);
         
         % check that any channels that are receiving flow below threshold
         % are disconnected from the network
@@ -148,7 +149,7 @@ iter = 0;
         tElapsedSinceSave_yr = tElapsedSinceSave_yr + tStep_sec/(secondsPerYear);
         if tElapsedSinceSave_yr >= tSaveInterval_yr || t == tMax_yr
            filename = fullfile(outputDir,[runName,'_time_',num2str(t/(secondsPerYear),'%4.2f'),'_yr.mat']);
-           save(filename,'grid','t','oceanLevel')
+           save(filename,'grid','t')
            tElapsedSinceSave_yr = 0; % reset elapsed time since save 
            fprintf('Saved file %s\n',filename)
         end

--- a/source/viz/functions/loadModelTimeseries.m
+++ b/source/viz/functions/loadModelTimeseries.m
@@ -7,6 +7,7 @@ tSaveInterval_yr = parameters.tSaveInterval_yr;
 tMax_yr = parameters.tMax_yr;
 timesWithData = 0:tSaveInterval_yr:tMax_yr;
 runName = parameters.runName;
+oceanLevel = parameters.oceanLevel;
 
 % Load timeseries of DEMs and store in a structure array,
 % dem.timeseries
@@ -24,6 +25,10 @@ for i=1:numel(timesWithData)
     dem.timeseries(i).z = grid.z;
     dem.timeseries(i).t = timesWithData(i);
     dem.timeseries(i).depositThickness = grid.z - z_initial;
+    
+    % look up ocean level at this time
+    indOceanLevel = find( dem.timeseries(i).t >=oceanLevel.timeStart_yr,1,'last');
+    dem.timeseries(i).oceanLevel.z = oceanLevel.z(indOceanLevel);
 end
 
 % get maximum deposit thickenss for the timesieres, which is used to set

--- a/source/viz/wrappers/wrapper_exportTopographyMovie.m
+++ b/source/viz/wrappers/wrapper_exportTopographyMovie.m
@@ -7,7 +7,7 @@ addpath ..\functions
 
 % % Run 1
 options.runName = 'run1';
-options.setMinElevZero = true; % uses minimum elevation in the set of DEMs to define zero
+options.setMinElevZero = false; % uses minimum elevation in the set of DEMs to define zero
 options.movieFrameRate = 2; % frames per second for movie
 options.movieFrameWidth = 24; % cm
 options.movieFrameHeight = 8; % cm

--- a/wrappers/wrapper_run1.m
+++ b/wrappers/wrapper_run1.m
@@ -70,7 +70,8 @@ tElapsedSinceSave_yr = 0; % variable to record elapsed time since saving
 inlet.row = 1; % set inlet point for water and sediment
 inlet.col = 50;
 boundaryCondition = 'closed';
-oceanLevel = 0.01; % elevation of ponded water, m (xi_theta in the paper)
+oceanLevel.timeStart_yr = linspace(0,tMax_yr,10); % times that define start of intervals with a particular ocean level
+oceanLevel.z = linspace(1,0,10); % timeseries elevation of ponded water, m (xi_theta in the paper). The length of this vector must equal the length of the previous parameter.
 
 % Flag to show a debugging figure. This is computationally expensive, so
 % only use to debug.


### PR DESCRIPTION
This PR enables the ocean level to vary in time, addressing #13. Changes apply to functions that input parameters, execute the model, and visualize results. Ocean level information is stored in the variable `oceanLevel`, which is now a structure array.  Ocean level is specified for time intervals by defining vectors for the start of the time interval and the corresponding ocean elevation, recorded in the structure array. Ocean level can increase, decrease or both over time.