### PR TITLE
Bugfix, and towards #53 (channel network)

### DIFF
--- a/source/routeFlow.m
+++ b/source/routeFlow.m
@@ -107,8 +107,8 @@ function grid=routeFlow(grid,inlet,Qw_inlet,gamma,Qw_mismatch_tolerance)
                 grid.Qw(branch1.startRow,branch1.startCol) =  grid.Qw(branch1.startRow,branch1.startCol) + branch1.Qw_received;
                 grid.Qw(branch2.startRow,branch2.startCol) =  grid.Qw(branch2.startRow,branch2.startCol) + branch2.Qw_received;
 
-                grid.Qw_toRoute(branch1.startRow,branch1.startCol) = branch1.Qw_received;
-                grid.Qw_toRoute(branch2.startRow,branch2.startCol) = branch2.Qw_received;
+                grid.Qw_toRoute(branch1.startRow,branch1.startCol) = grid.Qw_toRoute(branch1.startRow,branch1.startCol) + branch1.Qw_received;
+                grid.Qw_toRoute(branch2.startRow,branch2.startCol) = grid.Qw_toRoute(branch2.startRow,branch2.startCol) + branch2.Qw_received;
                 grid.Qw_toRoute(source.row,source.col) = 0;
 
                 % Record the flow partitioning information in the


### PR DESCRIPTION
I've been working on #53, and came across what I think is a bug. This PR fixes that bug.

The bug: missing water discharge at confluences. When >two flows went into one cell the `Qw` field is correctly added to anything that was already in the downstream cell ([see here](https://github.com/alimaye/sun-fan-delta-model/blob/9f28ab89a1c52c24ef8e193910f3f5e75ab04796/source/routeFlow.m#L107-L108)). However, the `Qw_toRoute` field is not updated by summation but rather replacement ([see here](https://github.com/alimaye/sun-fan-delta-model/blob/9f28ab89a1c52c24ef8e193910f3f5e75ab04796/source/routeFlow.m#L110-L111)). 

As a result of not summing, the amount of water that is routed from this confluence point would be wrong. Depending on the order of cells in the column ordering (i.e., [the routing order](https://github.com/alimaye/sun-fan-delta-model/blob/9f28ab89a1c52c24ef8e193910f3f5e75ab04796/source/routeFlow.m#L126)), this error could be large or small. Indeed, sometimes, the confluence discharge was set to 0 and no flow would be routed from that point (if it were later in the routing order). This would lead to `flowsToFrac_Qw_distributed` field being empty for this confluence cell when it was indexed in `updateTopography`.

I believe this is a bug, and I have corrected it, but want to be sure you agree it is a bug.

FWIW, this goes at least some of the way of making bifurcations and braid plains more stable: channels are not set to Qw=0 by mistake and thus abandoned.

![Screenshot from 2021-09-21 17-16-18](https://user-images.githubusercontent.com/8801322/134255059-f493aa29-8eda-432a-ade7-8ac9ac974311.png)


